### PR TITLE
Update getParam regex to support encoded ampersand

### DIFF
--- a/plugin/js/services/searchblox-service.js
+++ b/plugin/js/services/searchblox-service.js
@@ -185,7 +185,7 @@ angular.module('searchblox.service', [])
 
         function getParam(paramName, urlString) {
             paramName = paramName.replace(/[\[]/, "\\\[").replace(/[\]]/, "\\\]");
-            var regexS = "[\\?&]" + paramName + "=([^&#]*)";
+            var regexS = "[\\?&](?:amp;)?" + paramName + "=([^&#]*)";
             var regex = new RegExp(regexS);
             var results = regex.exec(urlString);
             if (results == null) {


### PR DESCRIPTION
The regular expression in the getParam method within searchblox-service.js only allowed for "?param=value" or "&param=value". The URL that the regex is run against could potentially contain an encoded ampersand (e.g. "&amp;amp;param=value"). This commit addresses the latter scenario.